### PR TITLE
Fade out title when transition called instead vanishing

### DIFF
--- a/coin-slider.js
+++ b/coin-slider.js
@@ -170,8 +170,13 @@
 			$('#cs-button-' + el.id + "-" + (imagePos[el.id] + 1)).addClass('cs-active');
 
 			if (titles[el.id][imagePos[el.id]]) {
-				$('#cs-title-' + el.id).css({ 'opacity' : 0 }).animate({ 'opacity' : params[el.id].opacity }, params[el.id].titleSpeed);
-				$('#cs-title-' + el.id).html(titles[el.id][imagePos[el.id]]);
+				$('#cs-title-' + el.id).animate({ 'opacity' : 0 }, {
+					duration: params[el.id].titleSpeed,
+					complete: function() {
+						$('#cs-title-' + el.id).html(titles[el.id][imagePos[el.id]]);
+						$('#cs-title-' + el.id).animate({ 'opacity' : params[el.id].opacity }, params[el.id].titleSpeed);
+					}
+				});
 			} else {
 				$('#cs-title-' + el.id).css('opacity',0);
 			}

--- a/coin-slider.js
+++ b/coin-slider.js
@@ -499,7 +499,8 @@
 
 			// create title bar
 			$('#' + el.id).append("<div class='cs-title' id='cs-title-" + el.id + "' style='position: absolute; bottom:0; left: 0; z-index: 1000;'></div>");
-
+			$('#cs-title-' + el.id).css('opacity', 0);
+			
 			setFields(el);
 
 			if(params[el.id].navigation){


### PR DESCRIPTION
This small update to avoid vanishing of title when next slide transition begins. I think it little bit better for the eye.
It fade it out (with titleSpeed duration), then put text in block (like before) and then fade in block.