### PR TITLE
Fix init images in iOS

### DIFF
--- a/coin-slider.js
+++ b/coin-slider.js
@@ -475,7 +475,7 @@
 
 			// create images, links and titles arrays
 			$.each($('#' + el.id + ' img'), function (i, item) {
-				images[el.id][i]		= $(item).attr('src');
+				images[el.id][i]		= $(item).attr('src') || item.src; // ios fix
 				links[el.id][i]			= $(item).parent().is('a') ? $(item).parent().attr('href') : '';
 				linksTarget[el.id][i]	= $(item).parent().is('a') ? $(item).parent().attr('target') : '';
 				titles[el.id][i]		= $(item).next().is('span') ? $(item).next().html() : '';


### PR DESCRIPTION
on iOS jQuery attr('src') return undefined if image not rendered. see http://stackoverflow.com/questions/19551496/jquery-undefined-src-when-using-attr-of-image
